### PR TITLE
Running powersell.exe with -ExecutionPolicy Bypass

### DIFF
--- a/wsudo/bin/wasudo.cmd
+++ b/wsudo/bin/wasudo.cmd
@@ -2,5 +2,5 @@
 setlocal
 set wsudo_commandLine=%*
 set wsudo_curDir=%CD%
-powershell.exe -f "%~dp0.\wsudoexec.ps1" -detach -stayOpen -title %~n0 -action prepare
+powershell.exe -ExecutionPolicy Bypass -NoProfile -NoLogo -File "%~dp0.\wsudoexec.ps1" -detach -stayOpen -title %~n0 -action prepare
 exit /b %ERRORLEVEL%

--- a/wsudo/bin/wasudox.cmd
+++ b/wsudo/bin/wasudox.cmd
@@ -2,5 +2,5 @@
 setlocal
 set wsudo_commandLine=%*
 set wsudo_curDir=%CD%
-start /b powershell.exe -f "%~dp0.\wsudoexec.ps1" -detach -title %~n0 -action prepare
+start /b powershell.exe -ExecutionPolicy Bypass -NoProfile -NoLogo -File "%~dp0.\wsudoexec.ps1" -detach -title %~n0 -action prepare
 exit /b %ERRORLEVEL%

--- a/wsudo/bin/wsudo.cmd
+++ b/wsudo/bin/wsudo.cmd
@@ -2,5 +2,5 @@
 setlocal
 set wsudo_commandLine=%*
 set wsudo_curDir=%CD%
-powershell.exe -f "%~dp0.\wsudoexec.ps1" -stayOpen -title %~n0 -action prepare
+powershell.exe -ExecutionPolicy Bypass -NoProfile -NoLogo -File "%~dp0.\wsudoexec.ps1" -stayOpen -title %~n0 -action prepare
 exit /b %ERRORLEVEL%

--- a/wsudo/bin/wsudoexec.ps1
+++ b/wsudo/bin/wsudoexec.ps1
@@ -34,7 +34,7 @@ switch($action) {
     $startProcessArgs = @{
       PassThru = $true
       FilePath = $powershell
-      ArgumentList = @("-File $PSCommandPath", '-action run', "-command $commandInfoEncoded")
+      ArgumentList = @("-ExecutionPolicy Bypass -NoProfile -NoLogo -File $PSCommandPath", '-action run', "-command $commandInfoEncoded")
       Verb = 'runAs'
     }
     $pi = Start-Process @startProcessArgs

--- a/wsudo/bin/wsudox.cmd
+++ b/wsudo/bin/wsudox.cmd
@@ -2,5 +2,5 @@
 setlocal
 set wsudo_commandLine=%*
 set wsudo_curDir=%CD%
-powershell.exe -f "%~dp0.\wsudoexec.ps1" -title %~n0 -action prepare
+powershell.exe -ExecutionPolicy Bypass -NoProfile -NoLogo -File "%~dp0.\wsudoexec.ps1" -title %~n0 -action prepare
 exit /b %ERRORLEVEL%

--- a/wsudo/wsudo.nuspec
+++ b/wsudo/wsudo.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>wsudo</id>
-        <version>1.0.1</version>
+        <version>1.0.2</version>
         <packageSourceUrl>https://github.com/noseratio/choco/tree/master/wsudo</packageSourceUrl>
         <title>wsudo</title>
         <authors>Andrew Nosenko</authors>
@@ -37,6 +37,7 @@ This implementation doesn't depend on the legacy Windows Script Host (`CScript`)
         <releaseNotes>
             1.0.0 (Feb 12, 2019) - Initial release
             1.0.1 (Feb 26, 2019) - Added wasudo/wasudox
+            1.0.2 (Mar 25, 2019) - Added `-ExecutionPolicy Bypass -NoProfile -NoLogo` PS options
         </releaseNotes>        
     </metadata>
     <files>


### PR DESCRIPTION
This allows to run `wsudo` on systems where `ExecutionPolicy` is `Restricted`.